### PR TITLE
add package-lock.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,6 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/node,visualstudiocode,windows,macos,linux,react
+
+## Custom ##
+package-lock.json


### PR DESCRIPTION
This way the dependency bot won't show up with security alerts from dependencies. 

Also, it is easier to install the project just with a `npm i` command.