### PR TITLE
Travis CI integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,4 @@ $RECYCLE.BIN/
 
 ## Custom ##
 package-lock.json
+.awcache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: node_js
+node_js:
+  - "stable"
+cache:
+  directories:
+    - node_modules
+script:
+  - npm run deploy:gh-pages
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $github_token
+  local_dir: dist
+  keep_history: true
+  on:
+    branch: ci-config

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ deploy:
   local_dir: dist
   keep_history: true
   on:
-    branch: ci-config
+    branch: master

--- a/base.webpack.config.js
+++ b/base.webpack.config.js
@@ -18,7 +18,6 @@ module.exports = {
   },
   entry: {
     app: ['regenerator-runtime/runtime', './main.tsx'],
-    appStyles: ['./sass/style.scss'],
   },
   optimization: {
     splitChunks: {

--- a/dev.webpack.config.js
+++ b/dev.webpack.config.js
@@ -6,6 +6,7 @@ module.exports = merge(base, {
   watch: true,
   output: {
     filename: './js/[name].js',
+    publicPath: '/',
   },
   module: {
     rules: [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "karumi-jobtest",
   "version": "1.0.0",
   "description": "Programming test for a Software Engineer position in Karumi.",
-  "homepage": "https://github.com/Firenz/karumi-jobtest#readme",
+  "homepage": "https://github.com/Firenz/karumi-jobtest/",
   "main": "index.js",
   "scripts": {
     "start": "rimraf dist && webpack-dev-server --mode development --open --config dev.webpack.config.js",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "jest --verbose -c ./config/test/jest.json",
     "test:watch": "npm test -- --watchAll -i --no-cache",
     "test:coverage": "rimraf coverage && jest -c ./config/test/jest.coverage.json --verbose",
-    "deploy:gh-pages": "npm run build:prod && gh-pages -d dist -r https://$github_token@github.com/Firenz/karumi-jobtest.git"
+    "deploy:gh-pages": "npm run build:prod && gh-pages-clean && gh-pages -d dist -r https://$github_token@github.com/Firenz/karumi-jobtest.git"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "jest --verbose -c ./config/test/jest.json",
     "test:watch": "npm test -- --watchAll -i --no-cache",
     "test:coverage": "rimraf coverage && jest -c ./config/test/jest.coverage.json --verbose",
-    "deploy:gh-pages": "npm run build:prod && gh-pages -d build"
+    "deploy:gh-pages": "npm run build:prod && gh-pages -d dist"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "jest --verbose -c ./config/test/jest.json",
     "test:watch": "npm test -- --watchAll -i --no-cache",
     "test:coverage": "rimraf coverage && jest -c ./config/test/jest.coverage.json --verbose",
-    "deploy:gh-pages": "npm run build:prod && gh-pages -d dist"
+    "deploy:gh-pages": "npm run build:prod && gh-pages -d dist -r https://$github_token@github.com/Firenz/karumi-jobtest.git"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "karumi-jobtest",
   "version": "1.0.0",
   "description": "Programming test for a Software Engineer position in Karumi.",
+  "homepage": "https://github.com/Firenz/karumi-jobtest#readme",
   "main": "index.js",
   "scripts": {
     "start": "rimraf dist && webpack-dev-server --mode development --open --config dev.webpack.config.js",
@@ -10,7 +11,8 @@
     "build:stats": "rimraf dist && webpack --mode development --config perf.webpack.config.js",
     "test": "jest --verbose -c ./config/test/jest.json",
     "test:watch": "npm test -- --watchAll -i --no-cache",
-    "test:coverage": "rimraf coverage && jest -c ./config/test/jest.coverage.json --verbose"
+    "test:coverage": "rimraf coverage && jest -c ./config/test/jest.coverage.json --verbose",
+    "deploy:gh-pages": "npm run build:prod && gh-pages -d build"
   },
   "repository": {
     "type": "git",
@@ -30,7 +32,6 @@
   "bugs": {
     "url": "https://github.com/Firenz/karumi-jobtest/issues"
   },
-  "homepage": "https://github.com/Firenz/karumi-jobtest#readme",
   "dependencies": {
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
@@ -72,6 +73,7 @@
     "eslint-plugin-react": "^7.20.3",
     "eslint-plugin-react-hooks": "^4.0.5",
     "file-loader": "^6.0.0",
+    "gh-pages": "^3.1.0",
     "html-loader": "^1.1.0",
     "html-webpack-plugin": "^4.3.0",
     "jest": "^26.1.0",

--- a/prod.webpack.config.js
+++ b/prod.webpack.config.js
@@ -5,6 +5,7 @@ const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 module.exports = merge(base, {
   mode: 'production',
   output: {
+    publicPath: '/karumi-jobtest/',
     filename: '[name].[chunkhash].js',
   },
   module: {


### PR DESCRIPTION
It's not the first time that I use Travis CI in a project but with webpack it was.

After some changes to the webpack config files, I learned that I could use the npm package `gh-pages` to deploy. But after fighting and looking in some articles ([this article](https://snyk.io/blog/deploying-a-gatsby-site-to-github-pages-from-travis-ci/) proved to be very useful, also [this one](https://survivejs.com/webpack/techniques/deploying/)), & [issues](https://github.com/tschaub/gh-pages/issues/12). I finally got it working as it was intended.