### PR TITLE
New try on making codecov work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
 script:
   - npm install
   - npm run deploy:gh-pages
+  - npm run test:coverage && codecov
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 deploy:


### PR DESCRIPTION
Despite having codecov installed in the repository, the badge still marks 0% coverage. Seems that coverage information doesn't reach the codecov website so following [this tutorial](https://github.com/codecov/example-node) my guess it's that I need to deploy the coverage folder on gh-pages too.

[This page seems to do it](http://brianyang.com/nodejs-with-github-pages-and-travis-ci-its-a-blogs-world-on-wordpress-com/), so at least I'm going to make a try on this.